### PR TITLE
Update data source URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ const nameToIdentifier = function nameToIdentifier ( name ) {
 
 const loadDishes = function loadDishes () {
     return new Promise( ( resolve, reject ) => {
-        request( 'http://www.lindholmen.se/pa-omradet/dagens-lunch', ( error, response, body ) => {
+        request( 'https://lindholmen.uit.se/omradet/dagens-lunch?embed-mode=iframe', ( error, response, body ) => {
             if ( error ) {
                 reject( error );
 


### PR DESCRIPTION
lindholmen.se have done a facelift and are extracting some functionality out into iframes. The lunch feature is one of them. 
The new URL is advertised on the page as the fallback URL if iframe doesn't work.